### PR TITLE
CHAOS-1161: handle multiple slo

### DIFF
--- a/chaos_ai/algorithm/genetic.py
+++ b/chaos_ai/algorithm/genetic.py
@@ -1,6 +1,7 @@
 import os
 import copy
 import json
+import yaml
 import random
 from typing import List
 
@@ -63,10 +64,10 @@ class GeneticAlgorithm:
             # Find the best individual in the current generation
             # Note: If there is no best solution, it will still consider based on sorting order
             fitness_scores = sorted(
-                fitness_scores, key=lambda x: x.fitness_score, reverse=True
+                fitness_scores, key=lambda x: x.fitness_result.fitness_score, reverse=True
             )
             self.best_of_generation.append(fitness_scores[0])
-            logger.info("Best Fitness: %f", fitness_scores[0].fitness_score)
+            logger.info("Best Fitness: %f", fitness_scores[0].fitness_result.fitness_score)
 
             # We don't want to add a same parent back to population since its already been included
             for fitness_result in fitness_scores:
@@ -146,7 +147,7 @@ class GeneticAlgorithm:
         Selects two parents using Roulette Wheel Selection (proportionate selection).
         Higher fitness means higher chance of being selected.
         """
-        total_fitness = sum([x.fitness_score for x in fitness_scores])
+        total_fitness = sum([x.fitness_result.fitness_score for x in fitness_scores])
 
         scenarios = [x.scenario for x in fitness_scores]
 
@@ -154,7 +155,7 @@ class GeneticAlgorithm:
             return random.choice(scenarios), random.choice(scenarios)
 
         # Normalize fitness scores to get probabilities
-        probabilities = [x.fitness_score / total_fitness for x in fitness_scores]
+        probabilities = [x.fitness_result.fitness_score / total_fitness for x in fitness_scores]
 
         # Select parents based on probabilities
         parent1 = random.choices(scenarios, weights=probabilities, k=1)[0]
@@ -229,8 +230,21 @@ class GeneticAlgorithm:
 
     def save(self):
         '''Save run results'''
+        self.save_config()
         self.save_generations()
         self.save_best_generations()
+
+    def save_config(self):
+        logger.info("Saving config file to config.yaml")
+        output_dir = self.output_dir
+        os.makedirs(output_dir, exist_ok=True)
+        with open(
+            os.path.join(output_dir, "config.yaml"),
+            "w",
+            encoding="utf-8"
+        ) as f:
+            config_data = self.config.model_dump(mode='json')
+            yaml.dump(config_data, f, sort_keys=False)
 
     def save_generations(self):
         logger.info("Saving results to generations.json")

--- a/chaos_ai/cli/cmd.py
+++ b/chaos_ai/cli/cmd.py
@@ -1,9 +1,11 @@
 import os
 import click
+from pydantic import ValidationError
 from chaos_ai.utils.fs import read_config_from_file
 from chaos_ai.utils.logger import get_module_logger
 
 from chaos_ai.algorithm.genetic import GeneticAlgorithm
+
 
 logger = get_module_logger(__name__)
 
@@ -24,10 +26,13 @@ def run(config: str, output: str = "./"):
         logger.warning("Config file not found.")
         exit(1)
 
-    logger.debug("Config File: %s", config)
-
-    parsed_config = read_config_from_file(config)
-    logger.debug("Successfully parsed config!")
+    try:
+        logger.debug("Config File: %s", config)
+        parsed_config = read_config_from_file(config)
+        logger.debug("Successfully parsed config!")
+    except ValidationError as err:
+        logger.error("Unable to parse config file: %s", err)
+        exit(1)
 
     genetic = GeneticAlgorithm(
         parsed_config,

--- a/chaos_ai/models/app.py
+++ b/chaos_ai/models/app.py
@@ -1,8 +1,20 @@
 from pydantic import BaseModel
 import datetime
 from enum import Enum
+from typing import List
 
 from chaos_ai.models.base_scenario import BaseScenario
+
+
+class FitnessScoreResult(BaseModel):
+    id: int
+    fitness_score: float
+    weighted_score: float
+
+
+class FitnessResult(BaseModel):
+    scores: List[FitnessScoreResult] = []
+    fitness_score: float = 0.0    # Overall fitness score
 
 
 class CommandRunResult(BaseModel):
@@ -13,7 +25,7 @@ class CommandRunResult(BaseModel):
     returncode: int         # Return code of Krkn-Hub scenario execution
     start_time: datetime.datetime   # Start date timestamp of the test 
     end_time: datetime.datetime     # End date timestamp of the test
-    fitness_score: float            # Overall fitness score measured for scenario.
+    fitness_result: FitnessResult   # Fitness result measured for scenario.
 
 
 class KrknRunnerType(str, Enum):

--- a/config/robot-shop-slos.yaml
+++ b/config/robot-shop-slos.yaml
@@ -1,0 +1,61 @@
+kubeconfig_file_path: "./tmp/kubeconfig.yaml"
+
+generations: 4
+population_size: 4
+
+fitness_function: 
+  include_krkn_failure: true
+  items:
+  - query: 'sum(kube_pod_container_status_restarts_total{namespace="robot-shop"})'
+    type: point
+    weight: 0.5
+  - query: 'sum(kube_pod_container_status_restarts_total{namespace="etcd"})'
+    type: point
+    weight: 0.5
+
+
+scenario:
+  pod-scenarios:
+    namespace:
+      - robot-shop
+    pod_label:
+      - service=mysql
+      - service=redis
+      - service=cart
+      - service=mongodb
+      - service=rabbitmq
+      - service=user
+      - service=shipping
+
+  application-outages:
+    namespace:
+      - robot-shop
+    pod_selector:
+      - "{service: mysql}"
+      - "{service: redis}"
+      - "{service: cart}"
+      - "{service: mongodb}"
+      - "{service: user}"
+      - "{service: shipping}"
+      - "{service: rabbitmq}"
+
+  container-scenarios:
+    namespace:
+    - openshift-dns
+    label_selector:
+    - dns.operator.openshift.io/daemonset-dns=default
+    container_name:
+    - dns
+    - kube-rbac-proxy
+
+  node-cpu-hog:
+    taints:
+      - '[]'
+    node_selector:
+      - ""
+
+  node-memory-hog:
+    taints:
+      - '[]'
+    node_selector:
+      - ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jupyterlab
 requests
 click
 krkn-lib@git+https://github.com/krkn-chaos/krkn-lib
+pyyaml


### PR DESCRIPTION
## Changes Added

- Users can now define multiple SLOs fitness function and provides floating-point weights (0-1) by using `fitness_function.items` list.
- Raw fitness score and weighed fitness scores are calculated and stored as part of the final result.
- A `config.yaml` file is created by default in the output directory that consists the initial test configuration.